### PR TITLE
Fix settings reference and add locale translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# community-fortune-telling
+﻿# community-fortune-telling
+
+Discourse plugin that displays a random fortune on the search page.
+
+## Setup
+
+1. Install the plugin in your Discourse instance.
+2. Enable **community_fortune_enabled** in the admin settings to toggle the feature.

--- a/assets/javascripts/discourse/initializers/community-fortune.js
+++ b/assets/javascripts/discourse/initializers/community-fortune.js
@@ -1,6 +1,6 @@
 import { apiInitializer } from "discourse/lib/api";
 
-export default apiInitializer("0.11.1", (api) => {
+export default apiInitializer("0.11.1", (api, settings) => {
   if (!settings.community_fortune_enabled) {
     return;
   }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,0 +1,4 @@
+en:
+  site_settings:
+    community_fortune_enabled: "Enable community fortune"
+    community_fortune_enabled_description: "Display a random fortune on the search page"

--- a/config/locales/server.ko.yml
+++ b/config/locales/server.ko.yml
@@ -1,0 +1,4 @@
+ko:
+  site_settings:
+    community_fortune_enabled: "커뮤니티 운세 사용"
+    community_fortune_enabled_description: "검색 페이지에 무작위 운세 배너를 표시합니다"


### PR DESCRIPTION
## Summary
- expose `community_fortune_enabled` to initializer
- add English and Korean site setting translations
- document plugin setup in README

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689066b88c28832c937bf60fb6a36cb4